### PR TITLE
Run tests for python2.7 and pypy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ python:
 
 install: "pip install -r requirements.txt"
 
-script: "coverage run --source dnsimple2/ -m unittest"
+script: "coverage run -m unittest discover"
   
 
 after_success:


### PR DESCRIPTION
The current command is not picking up tests under python2.7 and pypy. 

Here's the last passing build for posterity where the above holds true: https://travis-ci.org/indradhanush/dnsimple2-python/builds/281909259